### PR TITLE
タスク完了レコードを削除できるようにする

### DIFF
--- a/app/controllers/completions_controller.rb
+++ b/app/controllers/completions_controller.rb
@@ -5,4 +5,11 @@ class CompletionsController < ApplicationController
 
     redirect_to tasks_path
   end
+
+  def destroy
+    completion = Completion.find_by(user: current_user, task_id: params[:task_id])
+    completion.destroy
+
+    redirect_to tasks_path
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,12 @@ class User < ApplicationRecord
   def complete(task)
     completions.create!(task: task)
   end
+
+  def make_wip(task)
+    completions.find_by(task: task).destroy!
+  end
+
+  def done?(task)
+    completions.find_by(task: task).present?
+  end
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -3,7 +3,11 @@
   <% @tasks.each do |task| %>
     <li>
       <%= task.description %>
-      <%= button_to "done", task_completions_path(task) %>
+      <% if current_user.done?(task) %>
+        <%= button_to "not yet", task_completions_path(task), data: { turbo_method: :delete } %>
+      <% else %>
+        <%= button_to "done", task_completions_path(task) %>
+      <% end %>
     </li>
   <% end %>
 </ul>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,9 +4,9 @@
     <li>
       <%= task.description %>
       <% if current_user.done?(task) %>
-        <%= button_to "not yet", task_completions_path(task), data: { turbo_method: :delete } %>
+        <%= link_to "not yet", task_completions_path(task), data: { turbo_method: :delete } %>
       <% else %>
-        <%= button_to "done", task_completions_path(task) %>
+        <%= link_to "done", task_completions_path(task), data: { turbo_method: :post }  %>
       <% end %>
     </li>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: "tasks#index"
   resources :tasks, only: %i(index new create show destroy edit update) do
-    resources :completions, only: %i(create)
+    resource :completions, only: %i(create destroy)
   end
 
   get "/login", to: "sessions#new"


### PR DESCRIPTION
## 何を解決するのか
削除リンクについて、rails7 の data-turbo-methodを使うとき、内部的にリンクはフォームに変換される。
フォームを入れ子にはできないが、button_toを使うとpostアクションのフォームの内側にdeleteのフォームが入ってしまい、postアクションのリンクしか押せなくなってしまっていた。
link_to に直したところ、期待通り動いた。