### PR TITLE
タスク詳細画面でユーザー名とステータスを見られるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "factory_bot_rails", "~> 6.2.0"
 gem "bcrypt", "~> 3.1.13"
 gem "pry-rails"
 gem "bootstrap", "~> 5.0.0"
+gem "active_decorator"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_decorator (1.4.0)
+      activesupport
     activejob (7.0.3)
       activesupport (= 7.0.3)
       globalid (>= 0.3.6)
@@ -262,6 +264,7 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  active_decorator
   bcrypt (~> 3.1.13)
   bootsnap
   bootstrap (~> 5.0.0)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -20,6 +20,7 @@ class TasksController < ApplicationController
   end
 
   def show
+    @users = User.all
   end
 
   def edit

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,5 @@
+module UserDecorator
+  def task_status(task)
+    completions.where(task: task).exists? ? "DONE"  : "NOT YET"
+  end
+end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -12,6 +12,7 @@
       <% @users.each do |user| %>
         <tr>
           <td><%= user.name %></td>
+          <td><%= user.task_status(@task) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,6 +4,21 @@
 <%= @task.updated_at %>
 
 <div>
+  <table>
+    <thead>
+      <tr>name</tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td><%= user.name %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<div>
   <%= link_to "一覧に戻る", tasks_path %>
   <%= link_to "編集", edit_task_path %>
   <%= button_to "削除", @task, method: :delete, form: { data: { turbo_confirm: "タスクを削除します。よろしいですか？" } } %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -5,9 +5,6 @@
 
 <div>
   <table>
-    <thead>
-      <tr>name</tr>
-    </thead>
     <tbody>
       <% @users.each do |user| %>
         <tr>


### PR DESCRIPTION
## 何を解決するのか
タスク詳細画面で、各ユーザーの対応状況が一覧できるようにします。