### PR TITLE
自動でリマインドができるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,6 +16,7 @@ class TasksController < ApplicationController
     @task = current_user.tasks.new(task_params)
 
     if @task.save
+      @task.reserve_notification
       redirect_to tasks_path
     else
       render :new, status: :unprocessable_entity

--- a/app/models/notification_reservation.rb
+++ b/app/models/notification_reservation.rb
@@ -1,0 +1,3 @@
+class NotificationReservation < ApplicationRecord
+  belongs_to :task
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,5 +3,6 @@ class Task < ApplicationRecord
   validates :due_on, presence: true
 
   has_many :completions, dependent: :destroy
+  has_one :notification_reservation, dependent: :destroy
   belongs_to :user
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,4 +5,8 @@ class Task < ApplicationRecord
   has_many :completions, dependent: :destroy
   has_one :notification_reservation, dependent: :destroy
   belongs_to :user
+
+  def reserve_notification
+    create_notification_reservation!(reservation_date: due_on - 1.day)
+  end
 end

--- a/db/migrate/20221012150658_create_notification_reservations.rb
+++ b/db/migrate/20221012150658_create_notification_reservations.rb
@@ -1,0 +1,10 @@
+class CreateNotificationReservations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notification_reservations do |t|
+      t.date :reservation_date, null: false
+      t.references :task, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_06_145540) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_12_150658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_06_145540) do
     t.index ["task_id"], name: "index_completions_on_task_id"
     t.index ["user_id", "task_id"], name: "index_completions_on_user_id_and_task_id", unique: true
     t.index ["user_id"], name: "index_completions_on_user_id"
+  end
+
+  create_table "notification_reservations", force: :cascade do |t|
+    t.date "reservation_date", null: false
+    t.bigint "task_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_notification_reservations_on_task_id"
   end
 
   create_table "tasks", force: :cascade do |t|

--- a/lib/tasks/remind_task.rake
+++ b/lib/tasks/remind_task.rake
@@ -1,0 +1,35 @@
+namespace :remind do
+  desc "明日期限のタスクが未済であるユーザーにリマインドします。"
+  task notice: :environment do
+    puts "\n== 明日期限のタスクが未済のユーザーにリマインドをします。 =="
+
+    reservations_today = NotificationReservation.where(reservation_date: Date.today)
+
+    if reservations_today.blank?
+      abort "\n== 明日期限のタスクはありませんでした。 =="
+    end
+
+    users = User.all
+
+    reservations_today.each do |reservation|
+      task = reservation.task
+      notify_users = users.select {|user| !user.done?(task)}
+
+      if notify_users.empty?
+        abort "\n== 全員が完了していたため、リマインドを行いませんでした。 =="
+      end
+
+      notifier = Slack::Notifier.new(
+        Rails.application.credentials.slack.webhook_url,
+        channel: "timeline-handa"
+      )
+
+      notifier.post(
+        text: "『#{task.description}』の期限が明日に迫っています！対応よろしくお願いします。",
+        at: notify_users.pluck(:slack_member_id)
+      )
+
+      puts "\n== リマインドが完了しました。 =="
+    end
+  end
+end


### PR DESCRIPTION
## 何を解決するのか
明日期限のタスクが未済のユーザーに対してメンションをするリマインド機能を実装します。
現在の本番環境は Heroku なので、[Heroku Scheduler](https://devcenter.heroku.com/ja/articles/scheduler) を使って rake タスクを実行するようにします。

## やったこと
- [x] notification_reservation テーブルを作る
- [x] タスク作成時に notification_reservation レコードを作れるようにする
- [x] リマインドを行う rake タスクを作る