### PR TITLE
登録と編集をTurboStream化して一覧画面で行えるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,6 +17,7 @@ class TasksController < ApplicationController
 
     if @task.save
       @task.reserve_notification
+      flash.now.notice = "タスクを保存しました。"
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,7 +17,6 @@ class TasksController < ApplicationController
 
     if @task.save
       @task.reserve_notification
-      redirect_to tasks_path
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def turbo_stream_flash
+    turbo_stream.update "flash", partial: "layouts/flash"
+  end
 end

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |key, value| %>
+  <div class="alert <%= key == 'notice' ? 'alert-primary' : 'alert-danger' %> alert-dismissible">
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    <%= content_tag(:div, value, class: "key")%>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,12 +20,9 @@
           </div>
         <% end %>
         <div class="col my-4 mx-auto px-5" style="max-width: 980px">
-          <% flash.each do |key, value| %>
-            <div class="alert <%= key == 'notice' ? 'alert-primary' : 'alert-danger' %> alert-dismissible">
-              <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-              <%= content_tag(:div, value, class: "key")%>
-            </div>
-          <% end %>
+          <div id="flash">
+            <%= render "layouts/flash" %>
+          </div>
           <%= yield %>
         </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
             <%= render "layouts/sidebar" %>
           </div>
         <% end %>
-        <div class="col my-4 mx-auto px-5" style="max-width: 960px">
+        <div class="col my-4 mx-auto px-5" style="max-width: 980px">
           <% flash.each do |key, value| %>
             <div class="alert <%= key == 'notice' ? 'alert-primary' : 'alert-danger' %> alert-dismissible">
               <button type="button" class="btn-close" data-bs-dismiss="alert"></button>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag task do %>
   <%= form_with(model: task) do |f| %>
-  <div class="row py-2 px-4 border-top m-0">
+    <div class="row py-2 px-4 border-top m-0">
       <% if task.errors.any? %>
         <div style="color: red">
           <ul style="list-style: none;">
@@ -11,7 +11,7 @@
         </div>
       <% end %>
 
-      <div class="col-3 d-flex align-items-center">
+      <div class="col-2 d-flex align-items-center p-0">
         <%= f.date_field :due_on, class: "form-control" %>
       </div>
       <div class="col-8 position-relative">
@@ -19,8 +19,14 @@
       </div>
       <div class="col-1 d-flex align-items-center">
         <div class="d-flex justify-content-center">
-        <%= f.submit nil, class: "btn btn-outline-dark" %>
+          <%= f.submit nil, class: "btn btn-outline-dark" %>
+        </div>
       </div>
-  </div>
+      <div class="col-1 d-flex align-items-center justify-content-end">
+        <div class="d-flex justify-content-end">
+          <%= link_to "back", tasks_path, class: "link-secondary", style: "text-decoration: none" %>
+        </div>
+      </div>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,23 +1,26 @@
-<%= form_with(model: task) do |f| %>
-  <% if task.errors.any? %>
-    <div style="color: red">
-      <ul>
-        <% task.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<%= turbo_frame_tag task do %>
+  <%= form_with(model: task) do |f| %>
+  <div class="row py-2 px-4 border-top m-0">
+      <% if task.errors.any? %>
+        <div style="color: red">
+          <ul style="list-style: none;">
+            <% task.errors.each do |error| %>
+              <li><%= error.full_message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
 
-  <div>
-    <%= f.label :due_on %>
-    <%= f.date_field :due_on%>
+      <div class="col-3 d-flex align-items-center">
+        <%= f.date_field :due_on, class: "form-control" %>
+      </div>
+      <div class="col-8 position-relative">
+        <%= f.text_area :description, class: "form-control", rows: 3 %>
+      </div>
+      <div class="col-1 d-flex align-items-center">
+        <div class="d-flex justify-content-center">
+        <%= f.submit nil, class: "btn btn-outline-dark" %>
+      </div>
   </div>
-  <div>
-    <%= f.label :description %>
-    <%= f.text_field :description %>
-  </div>
-  <div>
-    <%= f.submit %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,17 +1,24 @@
-<div class="row py-2 px-4 border-top m-0">
-  <div class="col-2 d-flex align-items-center">
-    <%= l(task.due_on, format: :short) %>〆
-  </div>
-  <div class="col-8 position-relative d-flex align-items-center">
-    <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none" %>
-  </div>
-  <div class="col-2 d-flex align-items-center">
-    <div class="d-flex justify-content-center">
-      <% if current_user.done?(task) %>
-        <%= link_to "done", task_completions_path(task), data: { turbo_method: :delete }, class: "btn btn-dark" %>
-      <% else %>
-        <%= link_to "done", task_completions_path(task), data: { turbo_method: :post }, class: "btn btn-outline-secondary"  %>
-      <% end %>
+<%= turbo_frame_tag task do %>
+  <div class="row py-2 px-4 border-top m-0">
+    <div class="col-2 d-flex align-items-center">
+      <%= l(task.due_on, format: :short) %>〆
+    </div>
+    <div class="col-8 position-relative d-flex align-items-center">
+      <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none" %>
+    </div>
+    <div class="col-1 d-flex align-items-center">
+      <div class="d-flex justify-content-center">
+        <% if current_user.done?(task) %>
+          <%= link_to "done", task_completions_path(task), data: { turbo_method: :delete }, class: "btn btn-dark" %>
+        <% else %>
+          <%= link_to "done", task_completions_path(task), data: { turbo_method: :post }, class: "btn btn-outline-secondary"  %>
+        <% end %>
+      </div>
+    </div>
+    <div class="col-1 d-flex align-items-center">
+      <div class="d-flex justify-content-center">
+        <%= link_to "edit", edit_task_path(task), class: "btn btn-secondary" %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -4,7 +4,7 @@
       <%= l(task.due_on, format: :short) %>〆
     </div>
     <div class="col-8 position-relative d-flex align-items-center">
-      <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none" %>
+      <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none", data: { turbo: false } %>
     </div>
     <div class="col-1 d-flex align-items-center">
       <div class="d-flex justify-content-center">

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -15,10 +15,12 @@
         <% end %>
       </div>
     </div>
-    <div class="col-1 d-flex align-items-center">
-      <div class="d-flex justify-content-center">
-        <%= link_to "edit", edit_task_path(task), class: "btn btn-secondary" %>
+    <% if task.user_id == current_user.id %>
+      <div class="col-1 d-flex align-items-center">
+        <div class="d-flex justify-content-center">
+          <%= link_to "edit", edit_task_path(task), class: "btn btn-secondary" %>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.prepend "tasks", @task %>
+<%= turbo_stream.update Task.new, "" %>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.prepend "tasks", @task %>
 <%= turbo_stream.update Task.new, "" %>
+<%= turbo_stream_flash %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -10,15 +10,18 @@
           <%= link_to "リセット", tasks_path, class: "btn btn-outline-secondary" %>
         </div>
         <div class="col-4 d-grid">
-          <%= link_to "NEW", new_task_path, class: "btn btn-outline-secondary" %>
+          <%= link_to "NEW", new_task_path, class: "btn btn-outline-secondary", data: { turbo_frame: "new_task" } %>
         </div>
       </div>
     <% end %>
   </div>
 
-  <div class="card shadow mt-3">
 
+  <div class="card shadow mt-3">
+    <%= turbo_frame_tag "new_task" %>
+    <div id="tasks">
     <%= render @tasks %>
+    </div>
 
     <div class="d-flex justify-content-center mt-3">
       <%= paginate @tasks %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -11,7 +11,9 @@
     <div class="px-4 pb-4 row m-0">
       <div class="col-4 offset-8">
         <div class="d-flex justify-content-end">
-          <%= link_to "編集", edit_task_path, class:"btn btn-outline-secondary me-2" %>
+          <% if @task.user_id == current_user.id %>
+            <%= link_to "編集", edit_task_path, class:"btn btn-outline-secondary me-2" %>
+          <% end %>
           <%= button_to "削除", @task, method: :delete, form: { data: { turbo_confirm: "タスクを削除します。よろしいですか？" } }, class:"btn btn-outline-secondary" %>
         </div>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -159,9 +159,9 @@ ja:
     select:
       prompt: 選択してください
     submit:
-      create: 登録する
-      submit: 保存する
-      update: 更新する
+      create: 登録
+      submit: 保存
+      update: 更新
   number:
     currency:
       format:


### PR DESCRIPTION
## 何を解決するのか
タスクの登録および編集作業がスムーズに行えるようにするため、Turbo Streamを使って一覧画面から作業できるようにします。

## やったこと
- [x] 一覧画面に編集ボタンを追加し、クリック時に編集フォームを置換
- [x] フォームのスタイルを一覧画面に合わせて変更
- [x] キャンセルの実装
- [x] 作成フォームを一覧画面に表示させる
- [x] Turbo Streams を使って flash メッセージを実装