### PR TITLE
done ボタン押下時の動きを Turbo Streams 化する

### DIFF
--- a/app/views/completions/create.turbo_stream.erb
+++ b/app/views/completions/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace task do %>
+  <%= render partial: "tasks/completion", locals: { task: task } %>
+<% end %>

--- a/app/views/completions/destroy.turbo_stream.erb
+++ b/app/views/completions/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace task do %>
+  <%= render partial: "tasks/completion", locals: { task: task } %>
+<% end %>

--- a/app/views/tasks/_completion.html.erb
+++ b/app/views/tasks/_completion.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag "completion-#{task.id}" do %>
+  <% if current_user.done?(task) %>
+    <%= link_to "done", task_completions_path(task), :data => { :turbo_method => "delete", :turbo_frame => "done-#{task.id}" }, class: "btn btn-dark" %>
+  <% else %>
+    <%= link_to "done", task_completions_path(task), :data => { :turbo_method => "post", :turbo_fram => "done-#{task.id}" }, class: "btn btn-outline-secondary" %>
+  <% end %>
+<% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -7,11 +7,7 @@
       <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none", data: { turbo: false } %>
     </div>
     <div class="col-1 d-flex align-items-center justify-content-center">
-      <% if current_user.done?(task) %>
-        <%= link_to "done", task_completions_path(task), data: { turbo_method: :delete }, class: "btn btn-dark" %>
-      <% else %>
-        <%= link_to "done", task_completions_path(task), data: { turbo_method: :post }, class: "btn btn-outline-secondary" %>
-      <% end %>
+      <%= render partial: "tasks/completion", locals: { task: task } %>
     </div>
     <% if task.user_id == current_user.id %>
       <div class="col-1 d-flex align-items-center justify-content-center">


### PR DESCRIPTION
## 何を解決するのか
一覧画面の表示を TurboFrames 化したことに伴って、completions レコードを削除（タスク未済に変更）した時の挙動が意図しないものになってしまっていた（`DELETE http://localhost:3000/tasks 404 (Not Found)`と`Response has no matching <turbo-frame id="task_235"> element`が出ていた）ので修正します。

done ボタン部分をテンプレートに切り出し、Turbo Streams を使って completions レコード作成・削除時にレンダリングし直すようにします。