### PR TITLE
TurboFramesを使ってタスク詳細を一覧画面で表示できるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: %i(show destroy)
+  before_action :set_current_users_task, only: %i(edit update destroy)
 
   def index
     @search = Task.ransack(params[:q])
@@ -24,16 +24,14 @@ class TasksController < ApplicationController
   end
 
   def show
+    @task = Task.find(params[:id])
     @users = User.all
   end
 
   def edit
-    @task = current_user.tasks.find(params[:id])
   end
 
   def update
-    @task = current_user.tasks.find(params[:id])
-
     if @task.update(task_params)
       flash.now.notice = "タスクを更新しました。"
     else
@@ -48,8 +46,8 @@ class TasksController < ApplicationController
 
   private
 
-  def set_task
-    @task = Task.find(params[:id])
+  def set_current_users_task
+    @task = current_user.tasks.find(params[:id])
   end
 
   def task_params

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,5 +1,5 @@
 module UserDecorator
   def task_status(task)
-    completions.where(task: task).exists? ? "DONE"  : "NOT YET"
+    completions.where(task: task).exists? ? "Done"  : "Not yet"
   end
 end

--- a/app/views/tasks/_completion.html.erb
+++ b/app/views/tasks/_completion.html.erb
@@ -1,7 +1,7 @@
-<%= turbo_frame_tag "completion-#{task.id}" do %>
+<%= turbo_frame_tag "completion-#{task.id}", class:"d-grid" do %>
   <% if current_user.done?(task) %>
-    <%= link_to "done", task_completions_path(task), :data => { :turbo_method => "delete", :turbo_frame => "done-#{task.id}" }, class: "btn btn-dark" %>
+    <%= link_to "Done", task_completions_path(task), :data => { :turbo_method => "delete", :turbo_frame => "done-#{task.id}" }, class: "btn btn-dark" %>
   <% else %>
-    <%= link_to "done", task_completions_path(task), :data => { :turbo_method => "post", :turbo_fram => "done-#{task.id}" }, class: "btn btn-outline-secondary" %>
+    <%= link_to "Done", task_completions_path(task), :data => { :turbo_method => "post", :turbo_fram => "done-#{task.id}" }, class: "btn btn-outline-secondary" %>
   <% end %>
 <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -15,7 +15,7 @@
         <%= f.date_field :due_on, class: "form-control" %>
       </div>
       <div class="col-8 position-relative">
-        <%= f.text_area :description, class: "form-control", rows: 3 %>
+        <%= f.text_area :description, class: "form-control", rows: 7 %>
       </div>
       <div class="col-1 d-flex align-items-center">
         <div class="d-flex justify-content-center">

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,13 +1,16 @@
 <%= turbo_frame_tag task do %>
-  <div class="row py-2 px-4 border-top m-0">
-    <div class="col-2 d-flex align-items-center">
-      <%= l(task.due_on, format: :short) %>〆
+  <div class="border-top border-bottom">
+    <div class="px-5 py-4 m-0 row justify-content-between">
+      <p class="p-0 m-0 col-5 fw-bold"><%= l(task.due_on, format: :short) %>&nbsp;〆</p>
+      <div class="col-3 p-0">
+        <%= render partial: "tasks/completion", locals: { task: task } %>
+      </div>
     </div>
-    <div class="col-9 position-relative d-flex align-items-center">
+    <div class="px-5 py-4 m-0 position-relative">
       <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none" %>
     </div>
-    <div class="col-1 d-flex align-items-center justify-content-center">
-      <%= render partial: "tasks/completion", locals: { task: task } %>
+    <div class="px-5 py-4 m-0 d-flex justify-content-end">
+      <p class="m-0 col-7 text-end text-muted">created by <%= task.user.name %></p>
     </div>
   </div>
 <% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -4,7 +4,7 @@
       <%= l(task.due_on, format: :short) %>〆
     </div>
     <div class="col-8 position-relative d-flex align-items-center">
-      <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none", data: { turbo: false } %>
+      <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none" %>
     </div>
     <div class="col-1 d-flex align-items-center justify-content-center">
       <%= render partial: "tasks/completion", locals: { task: task } %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -3,16 +3,11 @@
     <div class="col-2 d-flex align-items-center">
       <%= l(task.due_on, format: :short) %>〆
     </div>
-    <div class="col-8 position-relative d-flex align-items-center">
+    <div class="col-9 position-relative d-flex align-items-center">
       <%= link_to task.description, task_path(task), class: "link-dark stretched-link py-3", style: "text-decoration: none" %>
     </div>
     <div class="col-1 d-flex align-items-center justify-content-center">
       <%= render partial: "tasks/completion", locals: { task: task } %>
     </div>
-    <% if task.user_id == current_user.id %>
-      <div class="col-1 d-flex align-items-center justify-content-center">
-        <%= link_to "edit", edit_task_path(task), class: "link-secondary", style: "text-decoration: none" %>
-      </div>
-    <% end %>
   </div>
 <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,39 +1,41 @@
-<div class="my-5">
-  <div>
-    <%= link_to "←", tasks_path, style: "text-decoration: none" %>
-  </div>
-  <div class="card shadow mt-3">
-    <div class="px-4 py-1 m-0 border-bottom row justify-content-between">
-      <p class="p-0 m-0 col-5"><%= l(@task.due_on, format: :default) %>&nbsp;〆</p>
-      <p class="m-0 col-7 text-end">created by <%= @task.user.name %></p>
+<%= turbo_frame_tag @task do %>
+  <div class="my-5">
+    <div>
+      <%= link_to "←", tasks_path, style: "text-decoration: none" %>
     </div>
-    <p class="px-4 pt-4 pb-4 m-0"><%= @task.description %></p>
-    <div class="px-4 pb-4 row m-0">
-      <div class="col-4 offset-8">
-        <div class="d-flex justify-content-end">
-          <% if @task.user_id == current_user.id %>
-            <%= link_to "編集", edit_task_path, class:"btn btn-outline-secondary me-2" %>
-          <% end %>
-          <%= button_to "削除", @task, method: :delete, form: { data: { turbo_confirm: "タスクを削除します。よろしいですか？" } }, class:"btn btn-outline-secondary" %>
-        </div>
+    <div class="card shadow mt-3">
+      <div class="px-4 py-1 m-0 border-bottom row justify-content-between">
+        <p class="p-0 m-0 col-5"><%= l(@task.due_on, format: :default) %>&nbsp;〆</p>
+        <p class="m-0 col-7 text-end">created by <%= @task.user.name %></p>
       </div>
-    </div>
-  </div>
-  <div class="mt-4 d-flex justify-content-end">
-    <%= link_to "リマインド", task_notifications_path(@task), data: { turbo_method: :post }, class:"btn btn-outline-dark" %>
-  </div>
-  <div class="card shadow mt-4">
-    <% @users.each do |user| %>
-      <div class="row py-2 px-4 border-top m-0">
-        <div class="col-10 position-relative d-flex align-items-center">
-          <p class="py-3 m-0"><%= user.name %></p>
-        </div>
-        <div class="col-2 d-flex align-items-center">
-          <div class="d-flex justify-content-center">
-            <%= user.task_status(@task) %>
+      <p class="px-4 pt-4 pb-4 m-0"><%= @task.description %></p>
+      <div class="px-4 pb-4 row m-0">
+        <div class="col-4 offset-8">
+          <div class="d-flex justify-content-end">
+            <% if @task.user_id == current_user.id %>
+              <%= link_to "編集", edit_task_path, class:"btn btn-outline-secondary me-2" %>
+            <% end %>
+            <%= button_to "削除", @task, method: :delete, form: { data: { turbo_confirm: "タスクを削除します。よろしいですか？" } }, class:"btn btn-outline-secondary" %>
           </div>
         </div>
       </div>
-    <% end %>
+    </div>
+    <div class="mt-4 d-flex justify-content-end">
+      <%= link_to "リマインド", task_notifications_path(@task), data: { turbo_method: :post }, class:"btn btn-outline-dark" %>
+    </div>
+    <div class="card shadow mt-4">
+      <% @users.each do |user| %>
+        <div class="row py-2 px-4 border-top m-0">
+          <div class="col-10 position-relative d-flex align-items-center">
+            <p class="py-3 m-0"><%= user.name %></p>
+          </div>
+          <div class="col-2 d-flex align-items-center">
+            <div class="d-flex justify-content-center">
+              <%= user.task_status(@task) %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,32 +1,30 @@
 <%= turbo_frame_tag @task do %>
-  <div class="my-5">
-    <div>
-      <%= link_to "←", tasks_path, style: "text-decoration: none" %>
-    </div>
-    <div class="card shadow mt-3">
-      <div class="px-4 py-1 m-0 border-bottom row justify-content-between">
+  <div>
+    <div class="border-bottom">
+      <div class="px-4 py-2 m-0 border-bottom row justify-content-between">
         <p class="p-0 m-0 col-5"><%= l(@task.due_on, format: :default) %>&nbsp;〆</p>
-        <p class="m-0 col-7 text-end">created by <%= @task.user.name %></p>
+        <p class="m-0 col-7 text-end text-muted">created by <%= @task.user.name %></p>
       </div>
       <p class="px-4 pt-4 pb-4 m-0"><%= @task.description %></p>
       <div class="px-4 pb-4 row m-0">
-        <div class="col-4 offset-8">
+        <div class="col-6 d-flex align-items-center text-start p-0">
+          <P class="m-0 d-flex align-items-center me-3"><%= link_to "back", tasks_path, class: "link-secondary", style: "text-decoration: none" %></p>
+        </div>
+        <div class="col-6">
           <div class="d-flex justify-content-end">
             <% if @task.user_id == current_user.id %>
-              <%= link_to "編集", edit_task_path, class:"btn btn-outline-secondary me-2" %>
+              <%= link_to "編集", edit_task_path, class:"btn btn-outline-secondary btn-sm me-2" %>
             <% end %>
-            <%= button_to "削除", @task, method: :delete, form: { data: { turbo_confirm: "タスクを削除します。よろしいですか？" } }, class:"btn btn-outline-secondary" %>
+            <%= button_to "削除", @task, method: :delete, form: { data: { turbo_confirm: "タスクを削除します。よろしいですか？" } }, class:"btn btn-outline-secondary btn-sm me-2" %>
+            <%= link_to "リマインド", task_notifications_path(@task), data: { turbo_method: :post }, class:"btn btn-light btn-sm" %>
           </div>
         </div>
       </div>
     </div>
-    <div class="mt-4 d-flex justify-content-end">
-      <%= link_to "リマインド", task_notifications_path(@task), data: { turbo_method: :post }, class:"btn btn-outline-dark" %>
-    </div>
-    <div class="card shadow mt-4">
+    <div>
       <% @users.each do |user| %>
-        <div class="row py-2 px-4 border-top m-0">
-          <div class="col-10 position-relative d-flex align-items-center">
+        <div class="row py-2 px-5 border-top m-0">
+          <div class="col-6 offset-2 position-relative d-flex align-items-center">
             <p class="py-3 m-0"><%= user.name %></p>
           </div>
           <div class="col-2 d-flex align-items-center">
@@ -34,6 +32,7 @@
               <%= user.task_status(@task) %>
             </div>
           </div>
+          <div class="col-2"></div>
         </div>
       <% end %>
     </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -14,8 +14,8 @@
           <div class="d-flex justify-content-end">
             <% if @task.user_id == current_user.id %>
               <%= link_to "編集", edit_task_path, class:"btn btn-outline-secondary btn-sm me-2" %>
+              <%= button_to "削除", @task, method: :delete, form: { data: { turbo_confirm: "タスクを削除します。よろしいですか？" } }, class:"btn btn-outline-secondary btn-sm me-2" %>
             <% end %>
-            <%= button_to "削除", @task, method: :delete, form: { data: { turbo_confirm: "タスクを削除します。よろしいですか？" } }, class:"btn btn-outline-secondary btn-sm me-2" %>
             <%= link_to "リマインド", task_notifications_path(@task), data: { turbo_method: :post }, class:"btn btn-light btn-sm" %>
           </div>
         </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag @task do %>
   <div>
-    <div class="border-bottom">
+    <div class="border-top border-bottom">
       <div class="px-4 py-2 m-0 border-bottom row justify-content-between">
         <p class="p-0 m-0 col-5"><%= l(@task.due_on, format: :default) %>&nbsp;〆</p>
         <p class="m-0 col-7 text-end text-muted">created by <%= @task.user.name %></p>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,16 +1,21 @@
 <%= turbo_frame_tag @task do %>
   <div>
-    <div class="border-top border-bottom">
-      <div class="px-4 py-2 m-0 border-bottom row justify-content-between">
-        <p class="p-0 m-0 col-5"><%= l(@task.due_on, format: :default) %>&nbsp;〆</p>
+    <div class="border-top">
+      <div class="px-5 py-4 m-0 row justify-content-between">
+        <p class="p-0 m-0 col-5 fw-bold"><%= l(@task.due_on, format: :short) %>&nbsp;〆</p>
+        <div class="col-3 p-0">
+          <%= render partial: "tasks/completion", locals: { task: @task } %>
+        </div>
+      </div>
+      <p class="px-5 pt-4 pb-4 m-0"><%= @task.description %></p>
+      <div class="px-5 py-4 m-0 d-flex justify-content-end">
         <p class="m-0 col-7 text-end text-muted">created by <%= @task.user.name %></p>
       </div>
-      <p class="px-4 pt-4 pb-4 m-0"><%= @task.description %></p>
-      <div class="px-4 pb-4 row m-0">
+      <div class="px-5 pb-4 row m-0 shadow-bottom">
         <div class="col-6 d-flex align-items-center text-start p-0">
-          <P class="m-0 d-flex align-items-center me-3"><%= link_to "back", tasks_path, class: "link-secondary", style: "text-decoration: none" %></p>
+          <P class="m-0 d-flex align-items-center me-3"><%= link_to "Back", tasks_path, class: "link-secondary", style: "text-decoration: none" %></p>
         </div>
-        <div class="col-6">
+        <div class="col-6 p-0">
           <div class="d-flex justify-content-end">
             <% if @task.user_id == current_user.id %>
               <%= link_to "編集", edit_task_path, class:"btn btn-outline-secondary btn-sm me-2" %>
@@ -23,7 +28,7 @@
     </div>
     <div>
       <% @users.each do |user| %>
-        <div class="row py-2 px-5 border-top m-0">
+        <div class="row py-2 px-5 border-top m-0 bg-light">
           <div class="col-6 offset-2 position-relative d-flex align-items-center">
             <p class="py-3 m-0"><%= user.name %></p>
           </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -56,7 +56,7 @@ ja:
     - 金曜日
     - 土曜日
     formats:
-      default: "%Y/%-m/%-d"
+      default: "%Y/%-m/%-d(%a)"
       long: "%Y年%-m月%-d日(%a)"
       short: "%-m/%-d(%a)"
     month_names:


### PR DESCRIPTION
## 何を解決するのか
一覧画面で文章をクリックしたときに、タスク表示部分をタスク詳細で置換するようにします。
併せて一覧画面全体としてのスタイル調整を行いました。

また画面遷移なく、手動リマインドやユーザーの対応状況を参照できるようになります。