### PR TITLE
Stimulusを使ってインスタントサーチを実装

### DIFF
--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="form"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="form"
 export default class extends Controller {
-  connect() {
+  submit() {
+    this.element.requestSubmit()
   }
 }

--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -3,6 +3,9 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="form"
 export default class extends Controller {
   submit() {
-    this.element.requestSubmit()
-  }
-}
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      this.element.requestSubmit()
+    }, 200)
+   }
+ }

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,12 +1,11 @@
 <div class="my-5">
   <div class="mb-5">
-    <%= search_form_for @search do |f| %>
+    <%= search_form_for @search, html: { data: { turbo_frame: "tasks-list", controller: "form", action: "input->form#submit"} } do |f| %>
       <div class="row g3 mb-3 mx-0">
         <div class="col-5">
           <%= f.search_field :description_cont, class: "form-control" %>
         </div>
         <div class="col-3 d-flex align-items-center">
-          <%= f.submit nil, class: "btn btn-secondary me-1" %>
           <%= link_to "リセット", tasks_path, class: "btn btn-outline-secondary" %>
         </div>
         <div class="col-4 d-grid">
@@ -18,13 +17,15 @@
 
 
   <div class="card shadow mt-3">
-    <%= turbo_frame_tag "new_task" %>
-    <div id="tasks">
-    <%= render @tasks %>
-    </div>
+    <%= turbo_frame_tag "tasks-list" do %>
+      <%= turbo_frame_tag "new_task" %>
+      <div id="tasks">
+      <%= render @tasks %>
+      </div>
 
-    <div class="d-flex justify-content-center mt-3">
-      <%= paginate @tasks %>
+      <div class="d-flex justify-content-center mt-3">
+        <%= paginate @tasks %>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>


### PR DESCRIPTION
## 何を解決するのか
タスクの検索体験をスムーズにするため、インスタントサーチを実装します。
キー入力毎にリクエストが飛ぶと体験的にもサーバー負荷的にも良くなさそうなので、一定の入力を間引いて複数の入力をまとめて一つとみなせるよう Debounce を併せて実装。

cf. https://aloerina01.github.io/blog/2017-08-03-1