### PR TITLE
FlashにToast使うようにした

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def turbo_stream_flash
-    turbo_stream.update "flash", partial: "layouts/flash"
+    turbo_stream.append "flashes", partial: "layouts/flash"
   end
 end

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="toast"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,7 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
+import { Toast } from "bootstrap"
 
 // Connects to data-controller="toast"
 export default class extends Controller {
   connect() {
+    const toast = new Toast(this.element)
+    toast.show()
   }
 }

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,6 +1,8 @@
 <% flash.each do |key, value| %>
-  <div class="alert <%= key == 'notice' ? 'alert-primary' : 'alert-danger' %> alert-dismissible">
-    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    <%= content_tag(:div, value, class: "key")%>
+  <div class="p-2 mb-2 toast hide text-white bg-info row" data-controller="toast">
+    <div class="toast-body col-10"><%= content_tag(:div, value, class: "key")%></div>
+    <div class="toast-header bg-info col-2">
+      <button class="btn-close btn-close-white" data-bs-dismiss="toast">
+    </div>
   </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,12 +20,10 @@
           </div>
         <% end %>
         <div class="col my-4 mx-auto px-5" style="max-width: 980px">
-          <div id="flash">
-            <%= render "layouts/flash" %>
-          </div>
           <%= yield %>
         </div>
       </div>
     </div>
+     <div id="flashes" class="position-fixed top-0 end-0" style="margin: 0.75rem"></div>
   </body>
 </html>


### PR DESCRIPTION
## 何を解決するのか
スタイリッシュなデザインにするためにFlash の表示に Bootstrap の Toast を利用します。

<img width="487" alt="スクリーンショット 2022-10-18 20 38 03" src="https://user-images.githubusercontent.com/70847530/196419332-01d8b7eb-b035-458f-a617-a3d3d5bbfb84.png">